### PR TITLE
day2-Genji - Fix for determining the files with viewAuth set to 'Everyone'

### DIFF
--- a/day2/task2.html
+++ b/day2/task2.html
@@ -46,7 +46,7 @@ tr#allFile {
   background:#8fe5ff;
 }
 li {
-    margin-top:5px;
+  margin-top:5px;
 }
 </style>
 </head>

--- a/day2/task2.js
+++ b/day2/task2.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Task2-1:fileManage obj contains the files and their permission settings
+// Task2-1: fileManage obj contains the files and their permission settings
 const fileManage =
 {
   f001: { folderName: "情報システム部", viewAuth: "Everyone", editAuth: "情報システム部", deleteAuth: "情報システム部" },
@@ -9,17 +9,16 @@ const fileManage =
 };
 
 // Task2-2 オブジェクトに格納されている値を全てブラウザに表⽰する
-//  Task2-2: Output the fileManage object in HTML using table's id
+// Task2-2: Output the fileManage object in HTML using table's id
 const file = Object.keys(fileManage);
 
 file.forEach((fileId) => {
-  // console.log('fileId');  // Expected f001,f002,f003
-  // console.log(fileId); 
+  // console.log(fileId); // Expected f001,f002,f003
 
   const innerLoop = Object.keys(fileManage[fileId]);
 
   innerLoop.forEach((fileProperty) => { // loops through files
-    console.log(fileId + '-' + fileProperty);
+    // console.log(fileId + '-' + fileProperty);
     document.getElementById(fileId + '-' + fileProperty).textContent = fileManage[fileId][fileProperty];
 
     // find the files with the view auth 'Everyone'

--- a/day2/task2.js
+++ b/day2/task2.js
@@ -19,7 +19,7 @@ file.forEach((fileId) => {
   const innerLoop = Object.keys(fileManage[fileId]);
 
   innerLoop.forEach((fileProperty) => { // loops through files
-    console.log(fileId+'-'+fileProperty);
+    console.log(fileId + '-' + fileProperty);
     document.getElementById(fileId + '-' + fileProperty).textContent = fileManage[fileId][fileProperty];
 
     // find the files with the view auth 'Everyone'

--- a/day2/task2.js
+++ b/day2/task2.js
@@ -19,17 +19,16 @@ file.forEach((fileId) => {
 
   innerLoop.forEach((fileProperty) => { // loops through files
     // console.log(fileId + '-' + fileProperty);
+
+    // Output the file permission settings to the 全てのフォルダとアクセス権を表示 table
     document.getElementById(fileId + '-' + fileProperty).textContent = fileManage[fileId][fileProperty];
 
-    // find the files with the view auth 'Everyone'
-    if (fileManage.fileId.fileProperty.viewAuth === "Everyone") {
-      console.log(fileManage.fileId.fileProperty.folderName);
+    // Determine which files have 'Everyone' as their view permission (viewAuth)
+    if (fileManage[fileId].viewAuth === "Everyone") {
+      console.log(fileManage[fileId].folderName);
     }
-    // display the foldername where viewAuth is 'Everyone'
 
-    // if ( === 'Everyone') {
-    // }
-
+    // Output the foldername where viewAuth is 'Everyone' as a list
   })
 
 });


### PR DESCRIPTION
Mistake:
* `fileManage.fileId.fileProperty.viewAuth`
* You cannot use "." dot notation with a variable... (`fileId` is a variable)

Solution:
* `fileManage[fileId].viewAuth`

Details:
https://www.tutorialspoint.com/dot-notation-vs-bracket-notation-in-javascript#:~:text=The%20dot%20notation%20is%20used,access%20object%20properties%20using%20variable.